### PR TITLE
Make bower a dev dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
-  - npm install -g bower

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
     "grunt-contrib-jshint": "~0.6.0",
-    "grunt-bump": "0.0.13"
+    "grunt-bump": "0.0.13",
+    "bower": "1.3.1"
   },
   "keywords": [
     "vtt",
@@ -42,6 +43,6 @@
   "homepage": "https://github.com/mozilla/node-vtt",
   "scripts": {
     "test": "./node_modules/.bin/grunt",
-    "postinstall": "bower install"
+    "postinstall": "./node_modules/.bin/bower install"
   }
 }


### PR DESCRIPTION
This way we can just get it from npm and use the local copy
in our postinstall script instead of installing it globally
on travis.
