### PR TITLE
Remove async dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "vtt.js": ">=0.10.1",
-    "async": "0.2.9",
     "node-phantom": "0.2.5",
     "mocha": "<=1.18.2"
   },


### PR DESCRIPTION
I don't think we have enough async code to justify
using this. It obfuscates the code more then making
it easier to read at the moment.

Closes #1.
