### PR TITLE
Pull text-encoding from npm instead of from vtt.js bower dist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,7 @@ on [PhantomJS](http://phantomjs.org/) from Node.
 Install
 =======
 
-`node-vtt` is on npm. It uses `bower` to install some of its dependencies so
-if you don't have it first you will need to intall it:
-
-```bash
-$ npm install -g bower
-```
-
-Then you can intall `node-vtt`:
+`node-vtt` is on npm. To install run:
 
 ```bash
 $ npm install node-vtt

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "vtt.js",
-  "dependencies": {
-    "vtt.js": ">=0.10.4"
-  }
-}

--- a/lib/basic.html
+++ b/lib/basic.html
@@ -17,8 +17,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="../bower_components/vtt.js/vtt.js"></script>
+    <script src="../node_modules/text-encoding/lib/encoding.js"></script>
+    <script src="../node_modules/vtt.js/lib/vtt.js"></script>
+    <script src="../node_modules/vtt.js/lib/vttcue.js"></script>
     <script src="../node_modules/vtt.js/lib/vttcue-extended.js"></script>
+    <script src="../node_modules/vtt.js/lib/vttregion.js"></script>
     <script src="../node_modules/vtt.js/lib/vttregion-extended.js"></script>
     <script type="text/javascript">
       // The properties on DOM objects that we care about testing.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-cli": "~0.1.9",
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-bump": "0.0.13",
-    "bower": "1.3.1"
+    "text-encoding": "0.0.0"
   },
   "keywords": [
     "vtt",
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/mozilla/node-vtt",
   "scripts": {
-    "test": "./node_modules/.bin/grunt && ./node_modules/.bin/mocha --reporter spec --timeout 40000 tests",
-    "postinstall": "./node_modules/.bin/bower install"
+    "test": "./node_modules/.bin/grunt && ./node_modules/.bin/mocha --reporter spec --timeout 40000 tests"
   }
 }


### PR DESCRIPTION
The text-encoding lib (formerly stringencoding) was previously not
on npm and so I elected to pull it from vtt.js bower distributable
instead of using a git submodule, since the current version of it
was broken. It's on npm now so we can pull directly from there and
get rid of our bower dependencies.
